### PR TITLE
Fix for compiling and running on newer versions of Java

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-mkdir ./out
+[ -d ./out ] || mkdir ./out
 find -name "*.java" > sources.txt
 javac -d ./out @sources.txt
 cd ./out

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,6 @@
 mkdir ./out
 find -name "*.java" > sources.txt
-BUILD_COMMAND="javac -d ./out @sources.txt"
-${BUILD_COMMAND} --add-exports=java.desktop/sun.awt=ALL-UNNAMED || \
-  echo "Command failed, retrying assuming older Java build" && ${BUILD_COMMAND}
+javac -d ./out @sources.txt
 cd ./out
 find ../src -name "*.png" -exec cp '{}' ./com/modsim/res/ \;
 jar cfm ../ModuleSim-Test.jar ../src/META-INF/MANIFEST.MF ./

--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,3 +1,2 @@
 Manifest-Version: 1.0
 Main-Class: com.modsim.Main
-Add-Exports: java.desktop/sun.awt

--- a/src/com/modsim/simulator/Sim.java
+++ b/src/com/modsim/simulator/Sim.java
@@ -12,7 +12,6 @@ import com.modsim.Main;
 import com.modsim.modules.*;
 import static com.modsim.modules.BaseModule.AvailableModules;
 import com.modsim.modules.parts.Port;
-import sun.awt.Mutex;
 
 import com.modsim.util.BinData;
 import com.modsim.util.CtrlPt;
@@ -20,7 +19,7 @@ import com.modsim.util.CtrlPt;
 public class Sim implements Runnable {
 
     private Thread thread;
-    public final Mutex lock = new Mutex();
+    public final Object lock = new Object();
 
     private int lastLinkInd = 0;
 

--- a/src/com/modsim/util/ModuleClipboard.java
+++ b/src/com/modsim/util/ModuleClipboard.java
@@ -185,6 +185,7 @@ public final class ModuleClipboard implements ClipboardOwner {
         
         if (hasTransferableFiles) {
             try {
+                @SuppressWarnings("unchecked")
                 List<File> files = (List<File>) contents.getTransferData(DataFlavor.javaFileListFlavor);
                 if (files.size() == 1) {
                     File file = files.get(0);


### PR DESCRIPTION
This PR is a clone of the one at https://github.com/TeachingTechnologistBeth/ModuleSim/pull/49 which allows ModuleSim to run on never versions of Java. It does so by removing the unnecessary dependency on `sun.awt.Mutex` which is no longer exported into the Java runtime by default.